### PR TITLE
fix(release): harden release checks

### DIFF
--- a/.github/workflows/2_bump.yml
+++ b/.github/workflows/2_bump.yml
@@ -93,7 +93,7 @@ jobs:
       - name: Prepare release notes
         run: |
           set -euo pipefail
-          awk '/^## [0-9]+\\.[0-9]+\\.[0-9]+ / {if(d) exit; d=1; next} d && /^## / {exit} d {print}' CHANGELOG.md > release_body.md
+          awk '/^## [0-9]+\.[0-9]+\.[0-9]+ / {if(d) exit; d=1; next} d && /^## / {exit} d {print}' CHANGELOG.md > release_body.md
           if ! grep -q '[^[:space:]]' release_body.md; then
             echo "::error::Release notes for the first CHANGELOG entry are empty."
             exit 1

--- a/scripts/audit_dependencies.py
+++ b/scripts/audit_dependencies.py
@@ -39,6 +39,10 @@ def main() -> None:
             [
                 uv_executable,
                 "run",
+                "--frozen",
+                "--all-extras",
+                "--group",
+                "dev",
                 "pip-audit",
                 "--disable-pip",
                 "--require-hashes",


### PR DESCRIPTION
## Summary

- fix the AWK release-heading expression in the tag workflow
- restore non-empty release body generation for the prepared 1.1.0 release
- make the standalone dependency audit restore the locked dev group and all optional extras before invoking pip-audit

## Root cause

The YAML literal block passed doubled backslashes unchanged to AWK, so the expression searched for literal backslashes instead of version separators. The release completion sequence also exposed that docs-only synchronization removed pip-audit and optional drivers before later checks.

## Validation

- exact release-note extraction regression
- actionlint and zizmor
- immutable dependency pin validation
- Ruff, ty and deptry
- 14 import, 50 service integration and 433 unit tests
- 100% statement and branch coverage
- docs build, wheel and sdist build, artifact review
- pip-audit and full prek run