### PR TITLE
fix(postgresql): honor SQLAlchemy asyncpg ssl mode

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,9 @@
+## 1.1.1 (2026-08-08)
+
+### Fixes
+
+- **postgresql**: honor SQLAlchemy asyncpg `ssl` DSN options, while rejecting conflicting `ssl` and `sslmode` values
+
 ## 1.1.0 (2026-08-08)
 
 ### Features

--- a/docs/dsn-formats.md
+++ b/docs/dsn-formats.md
@@ -15,6 +15,11 @@ Checks that support `from_dsn()` accept these URL schemes:
 
 The asyncpg check forwards `disable`, `allow`, `prefer`, `require`, `verify-ca`, and `verify-full` to asyncpg when no certificate files are configured, preserving the driver's native SSL-mode behavior. `verify-full` validates the server certificate and hostname; it does not require a client certificate.
 
+Raw asyncpg/libpq URLs select the mode with `sslmode=require`. SQLAlchemy asyncpg URLs commonly
+use `postgresql+asyncpg://...?...&ssl=require`; the asyncpg check accepts that `ssl` spelling as a
+compatibility alias. When both `ssl` and `sslmode` are present they must be identical, otherwise DSN
+validation fails closed.
+
 `sslrootcert` configures the CA used to verify the server. `sslcert` and `sslkey` are optional client-authentication material and must form a usable certificate chain. A key without a certificate is rejected.
 
 ### Certificate rotation

--- a/fast_healthchecks/__init__.py
+++ b/fast_healthchecks/__init__.py
@@ -19,7 +19,7 @@ if TYPE_CHECKING:
         HealthCheckTimeoutError,
     )
 
-__version__ = "1.1.0"
+__version__ = "1.1.1"
 
 _EXPORTS = {
     "Check": ("fast_healthchecks.checks.types", "Check"),

--- a/fast_healthchecks/checks/postgresql/asyncpg.py
+++ b/fast_healthchecks/checks/postgresql/asyncpg.py
@@ -63,6 +63,7 @@ class PostgreSQLAsyncPGHealthCheck(BasePostgreSQLHealthCheck[HealthCheckResult])
 
     _config: PostgresAsyncPGConfig
     _name: str
+    _sslmode_query_keys = ("sslmode", "ssl")
 
     def __init__(
         self,

--- a/fast_healthchecks/checks/postgresql/base.py
+++ b/fast_healthchecks/checks/postgresql/base.py
@@ -5,7 +5,7 @@ from __future__ import annotations
 import ssl
 from abc import abstractmethod
 from functools import lru_cache
-from typing import Generic, cast
+from typing import ClassVar, Generic, cast
 from urllib.parse import SplitResult, unquote, urlsplit
 
 from fast_healthchecks.checks._base import DEFAULT_HC_TIMEOUT, HealthCheckDSN, T_co
@@ -74,6 +74,8 @@ def create_ssl_context(
 class BasePostgreSQLHealthCheck(HealthCheckDSN[T_co, PostgresParseDsnResult], Generic[T_co]):
     """Base class for PostgreSQL health checks."""
 
+    _sslmode_query_keys: ClassVar[tuple[str, ...]] = ("sslmode",)
+
     @classmethod
     def _allowed_schemes(cls) -> tuple[str, ...]:
         return ("postgresql", "postgres")
@@ -128,7 +130,13 @@ class BasePostgreSQLHealthCheck(HealthCheckDSN[T_co, PostgresParseDsnResult], Ge
         """
         parse_result: SplitResult = urlsplit(dsn)
         query = parse_query_string(parse_result.query)
-        sslmode: SslMode = cls.validate_sslmode(query.get("sslmode", "disable"))
+        sslmodes = {key: cls.validate_sslmode(query[key]) for key in cls._sslmode_query_keys if key in query}
+        if len(set(sslmodes.values())) > 1:
+            aliases = " and ".join(sorted(sslmodes))
+            msg = f"Conflicting PostgreSQL TLS modes in {aliases}"
+            raise ValueError(msg) from None
+        default_sslmode: SslMode = "disable"
+        sslmode: SslMode = next(iter(sslmodes.values()), default_sslmode)
         sslcert_raw: str | None = query.get("sslcert")
         sslkey_raw: str | None = query.get("sslkey")
         sslrootcert_raw: str | None = query.get("sslrootcert")

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "fast-healthchecks"
-version = "1.1.0"
+version = "1.1.1"
 description = "Fast Healthchecks"
 readme = "README.md"
 license = "MIT"

--- a/tests/unit/checks/postgresql/test_asyncpg.py
+++ b/tests/unit/checks/postgresql/test_asyncpg.py
@@ -723,6 +723,65 @@ def test_from_dsn(
         assert_check_init(lambda: PostgreSQLAsyncPGHealthCheck.from_dsn(*args, **kwargs), expected, exception)
 
 
+@pytest.mark.parametrize("sslmode", ["disable", "allow", "prefer", "require", "verify-ca", "verify-full"])
+def test_from_dsn_accepts_sqlalchemy_asyncpg_ssl_alias(sslmode: str) -> None:
+    """The SQLAlchemy asyncpg dialect uses ``ssl`` where raw asyncpg URLs use ``sslmode``."""
+    assert_check_init(
+        lambda: PostgreSQLAsyncPGHealthCheck.from_dsn(
+            f"postgresql+asyncpg://postgres:pass@localhost:5432/db?ssl={sslmode}",
+        ),
+        {
+            "host": "localhost",
+            "port": 5432,
+            "user": "postgres",
+            "password": "pass",
+            "database": "db",
+            "ssl": sslmode,
+            "direct_tls": False,
+            "timeout": 5.0,
+            "name": "PostgreSQL",
+        },
+        None,
+    )
+
+
+def test_from_dsn_accepts_matching_ssl_aliases() -> None:
+    """Equivalent SQLAlchemy and libpq options remain unambiguous."""
+    assert_check_init(
+        lambda: PostgreSQLAsyncPGHealthCheck.from_dsn(
+            "postgresql+asyncpg://postgres:pass@localhost:5432/db?ssl=require&sslmode=require",
+        ),
+        {
+            "host": "localhost",
+            "port": 5432,
+            "user": "postgres",
+            "password": "pass",
+            "database": "db",
+            "ssl": "require",
+            "direct_tls": False,
+            "timeout": 5.0,
+            "name": "PostgreSQL",
+        },
+        None,
+    )
+
+
+def test_from_dsn_rejects_conflicting_ssl_aliases() -> None:
+    """Conflicting aliases fail closed instead of silently weakening TLS."""
+    with pytest.raises(ValueError, match="Conflicting PostgreSQL TLS modes"):
+        PostgreSQLAsyncPGHealthCheck.from_dsn(
+            "postgresql+asyncpg://postgres:pass@localhost:5432/db?ssl=require&sslmode=disable",
+        )
+
+
+def test_from_dsn_rejects_invalid_sqlalchemy_ssl_alias() -> None:
+    """The SQLAlchemy alias is constrained to asyncpg's documented modes."""
+    with pytest.raises(ValueError, match="Invalid sslmode: broken"):
+        PostgreSQLAsyncPGHealthCheck.from_dsn(
+            "postgresql+asyncpg://postgres:pass@localhost:5432/db?ssl=broken",
+        )
+
+
 @pytest.mark.asyncio
 async def test_asyncpg_connect_args_kwargs() -> None:
     """Constructor and SSL args are passed through to asyncpg connect."""

--- a/uv.lock
+++ b/uv.lock
@@ -812,7 +812,7 @@ pydantic = [
 
 [[package]]
 name = "fast-healthchecks"
-version = "1.1.0"
+version = "1.1.1"
 source = { editable = "." }
 
 [package.optional-dependencies]


### PR DESCRIPTION
## Summary

- support SQLAlchemy asyncpg DSNs using `ssl=<mode>`
- preserve native asyncpg TLS modes and reject conflicting `ssl`/`sslmode` values
- add regression coverage and prepare the `1.1.1` patch release

## Validation

- `just lint`
- `just pin-check`
- `pytest -n auto --maxprocesses=8 -m unit tests/unit` (442 passed)
- targeted asyncpg suite (52 passed)
- docs build
- wheel and sdist build

This fixes the production regression introduced in 1.1.0 where `postgresql+asyncpg://...?ssl=require` was parsed as TLS disabled.