### PR TITLE
chore: keep Codacy focused on production code

### DIFF
--- a/.codacy.yml
+++ b/.codacy.yml
@@ -1,0 +1,5 @@
+---
+engines:
+  trivy:
+    exclude_paths:
+      - "tests/**"


### PR DESCRIPTION
Adds the repository-owned Codacy exclusions for test fixtures. The organization policy now uses Trivy as an advisory complement to the existing Ruff, ty, CodeQL, and pip-audit checks; tests remain covered by the repository-native quality stack.